### PR TITLE
migrate to JSON3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,9 @@ authors = ["Alexandr Romanenko <waralex@gmail.com>"]
 version = "0.1.0"
 
 [deps]
-JSON2 = "2535ab7d-5cd8-5a07-80ac-9b1792aadce3"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-
 [compat]
-JSON2 = "0.3.1"
+JSON3 = "1"
 julia = "1.2"

--- a/src/DashBase.jl
+++ b/src/DashBase.jl
@@ -1,5 +1,5 @@
 module DashBase
-import JSON2
+import JSON3
 include("components.jl")
 include("registry.jl")
 export Component, push_prop!, get_name, get_type, get_namespace,

--- a/src/components.jl
+++ b/src/components.jl
@@ -55,8 +55,5 @@ Base.propertynames(comp::Component) = collect(get_available_props(comp))
 
 push_prop!(component::Component, prop::Symbol, value) = push!(component.props, prop=>to_dash(value))
 
-JSON2.@format Component begin
-    name => (exclude = true,)
-    available_props => (exclude = true,)
-    wildcard_regex => (exclude = true,)
-end
+JSON3.StructTypes.StructType(::Type{DashBase.Component}) = JSON3.StructTypes.Struct()
+JSON3.StructTypes.excludes(::Type{DashBase.Component}) = (:name, :available_props, :wildcard_regex)

--- a/test/components.jl
+++ b/test/components.jl
@@ -1,5 +1,5 @@
 using DashBase
-using JSON2
+using JSON3
 
 @testset "components creation" begin
     test_comp = Component("html_div", "Div", "dash_html_components",
@@ -29,9 +29,9 @@ using JSON2
      id = 10, 
      key = 1
      )
-    json = JSON2.write(test_comp)
-    res = JSON2.read(json)
-    @test keys(res) == (:type, :namespace, :props)
+    json = JSON3.write(test_comp)
+    res = JSON3.read(json)
+    @test all(keys(res) .== [:type, :namespace, :props])
     @test sort(collect(keys(res.props))) == sort([:id, :n_clicks, Symbol("data-id")])
     @test res.props.id == 10
     @test res.props.n_clicks == 1


### PR DESCRIPTION
This should avoid downstream Dash.jl depending on JSON, JSON2, and JSON3.

This should be released as v0.2 to avoid downstream regressions.