### PR TITLE
Fixup `DashBasePlotsExt`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,25 +5,20 @@ version = "0.2.0"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
-[weakdeps]
-PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
-PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+[compat]
+JSON3 = "1"
+PlotlyBase = "0.8"
+PlotlyJS = "0.18"
+Plots = "1"
+Requires = "1.3"
+julia = "1.6"
 
 [extensions]
 DashBasePlotlyBaseExt = "PlotlyBase"
 DashBasePlotlyJSExt = "PlotlyJS"
 DashBasePlotsExt = "Plots"
-
-[compat]
-JSON3 = "1"
-Plots = "1"
-julia = "1.6"
-PlotlyBase = "0.8"
-PlotlyJS = "0.18"
-PackageExtensionCompat = "1"
 
 [extras]
 PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
@@ -34,3 +29,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Plots", "PlotlyBase", "PlotlyJS", "PlotlyKaleido"]
+
+[weakdeps]
+PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
+PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/ext/DashBasePlotlyBaseExt.jl
+++ b/ext/DashBasePlotlyBaseExt.jl
@@ -1,8 +1,10 @@
 module DashBasePlotlyBaseExt
 
-import DashBase
-import PlotlyBase
-import PlotlyBase.JSON
+using DashBase
+
+isdefined(Base, :get_extension) ? (using PlotlyBase) : (using ..PlotlyBase)
+
+const JSON = PlotlyBase.JSON
 
 function DashBase.to_dash(p::PlotlyBase.Plot)
     data = JSON.lower(p)

--- a/ext/DashBasePlotlyJSExt.jl
+++ b/ext/DashBasePlotlyJSExt.jl
@@ -1,7 +1,8 @@
 module DashBasePlotlyJSExt
 
-import PlotlyJS
-import DashBase
+using DashBase
+
+isdefined(Base, :get_extension) ? (using PlotlyJS) : (using ..PlotlyJS)
 
 function DashBase.to_dash(p::PlotlyJS.SyncPlot)
     DashBase.to_dash(p.plot)

--- a/ext/DashBasePlotsExt.jl
+++ b/ext/DashBasePlotsExt.jl
@@ -1,8 +1,8 @@
 module DashBasePlotsExt
 
-import Plots
-import DashBase
+using DashBase
 
+isdefined(Base, :get_extension) ? (using Plots) : (using ..Plots)
 
 function DashBase.to_dash(p::Plots.Plot{Plots.PlotlyBackend})
     return if haskey(Base.loaded_modules, Base.PkgId(Base.UUID("a03496cd-edff-5a9b-9e67-9cda94a718b5"), "PlotlyBase")) &&

--- a/ext/DashBasePlotsExt.jl
+++ b/ext/DashBasePlotsExt.jl
@@ -8,11 +8,16 @@ function DashBase.to_dash(p::Plots.Plot{Plots.PlotlyBackend})
     return if haskey(Base.loaded_modules, Base.PkgId(Base.UUID("a03496cd-edff-5a9b-9e67-9cda94a718b5"), "PlotlyBase")) &&
         haskey(Base.loaded_modules, Base.PkgId(Base.UUID("f2990250-8cf9-495f-b13a-cce12b45703c"), "PlotlyKaleido"))
         # Note: technically it would be sufficient if PlotlyBase is loaded, but thats how it is currently handled by Plots.jl
-        Plots.plotlybase_syncplot(p)
+        sp = Plots.plotlybase_syncplot(p)
+        DashBase.to_dash(sp)
     else
-        (data = Plots.plotly_series(p), layout = Plots.plotly_layout(p))
+        Dict(:data => Plots.plotly_series(p), :layout => Plots.plotly_layout(p))
     end
 end
-DashBase.to_dash(p::Plots.Plot{Plots.PlotlyJSBackend}) = Plots.plotlyjs_syncplot(p)
+
+function DashBase.to_dash(p::Plots.Plot{Plots.PlotlyJSBackend})
+    sp = Plots.plotlyjs_syncplot(p)
+    return DashBase.to_dash(sp)
+end
 
 end

--- a/src/DashBase.jl
+++ b/src/DashBase.jl
@@ -1,6 +1,5 @@
 module DashBase
 import JSON3
-import PackageExtensionCompat
 include("components.jl")
 include("registry.jl")
 export Component, push_prop!, get_name, get_type, get_namespace,
@@ -9,8 +8,16 @@ get_dash_dependencies, get_dash_renderer_pkg, get_componens_pkgs,
 has_relative_path, has_dev_path, has_external_url, get_type,
 get_external_url, get_dev_path, get_relative_path
 
+@static if !isdefined(Base, :get_extension)
+using Requires
+end
+
 function __init__()
-    PackageExtensionCompat.@require_extensions
+    @static if !isdefined(Base, :get_extension)
+        @require PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5" include("../ext/DashBasePlotlyBaseExt.jl")
+        @require PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a" include("../ext/DashBasePlotlyJSExt.jl")
+        @require Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80" include("../ext/DashBasePlotsExt.jl")
+    end
 end
 
 end # module

--- a/test/test_ext.jl
+++ b/test/test_ext.jl
@@ -1,25 +1,36 @@
-using DashBase
 using Test
-using Plots
-plotlyjs()
+using DashBase
+import PlotlyBase
+import PlotlyJS
+import Plots
 
-@testset "PlotlyJS" begin
-    pl = @test_nowarn DashBase.to_dash(plot(1:5))
-    @test pl isa PlotlyJS.SyncPlot
-    pl = @test_nowarn DashBase.to_dash(pl)
-    @test haskey(pl, :layout)
-    @test haskey(pl, :data)
-    @test haskey(pl, :frames)
-    @test !haskey(pl, :config)
+function run_assertions(pl)
+    obj = @test_nowarn DashBase.to_dash(pl)
+    @test obj isa Dict{Symbol, Any}
+    @test obj[:data][1][:y] == [1, 2, 3, 4, 5]
+    @test haskey(obj, :layout)
+    @test haskey(obj, :frames)
+    @test !haskey(obj, :config)
 end
 
-plotly()
-@testset "PlotlyBase" begin
-    pl = @test_nowarn DashBase.to_dash(plot(1:5))
-    @test pl isa PlotlyBase.Plot
-    pl = @test_nowarn DashBase.to_dash(pl)
-    @test haskey(pl, :layout)
-    @test haskey(pl, :data)
-    @test haskey(pl, :frames)
-    @test !haskey(pl, :config)
+@testset "DashBasePlotlyBaseExt" begin
+    pl = PlotlyBase.Plot(1:5)
+    run_assertions(pl)
+end
+
+@testset "DashBasePlotsJSExt" begin
+    pl = PlotlyJS.plot(1:5)
+    run_assertions(pl)
+end
+
+@testset "DashBasePlotsExt + plotlyjs()" begin
+    Plots.plotlyjs()
+    pl = Plots.plot(1:5)
+    run_assertions(pl)
+end
+
+@testset "DashBasePlotsExt + plotly()" begin
+    Plots.plotly()
+    pl = Plots.plot(1:5)
+    run_assertions(pl)
 end


### PR DESCRIPTION
From the [Dash.jl callback source](https://github.com/plotly/Dash.jl/blob/d01ce73b4667991f3441e167816fd00a24a35a54/src/handler/processors/callback.jl#L29), `DashBase.to_dash` is called once and is not part of a custom `JSON3.StructTypes.lower` definition.

So, `DashBase.to_dash` is expected to return the same type after one call for all its methods.

If not, `JSON3.write` can run into infinite loops. Consider

```jl
using Dash
using Plots
plotlyjs()

app = dash()
app.layout = html_div() do
    dcc_graph(id = "graph", figure = plot((1:10, 1:10))),
    html_button("draw", id = "draw"),
    html_div("", id = "status")
end

callback!(app,
          Output("graph", "figure"),
          Output("status", "children"),
          Input("draw", "n_clicks")) do nclicks
    return if isnothing(nclicks)
        no_update(), "first"
    else
        plot([(1:10, 1:10), (1:10, 1:2:20)]), "second"
    end
end

run_server(app)
```

with `Dash@1.3.0` and the current `DashBase#master` (with the https://github.com/plotly/DashBase.jl/pull/4 merge commit as HEAD), we get

![image](https://github.com/plotly/DashBase.jl/assets/6675409/d4166a58-c00f-4048-99c2-052b9165f74a)
