### PR TITLE
Replace with `PackageExtensionCompat`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,25 +5,20 @@ version = "0.2.0"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
-[weakdeps]
-PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
-PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+[compat]
+JSON3 = "1"
+PlotlyBase = "0.8"
+PlotlyJS = "0.18"
+Plots = "1"
+Requires = "1.3"
+julia = "1.6"
 
 [extensions]
 DashBasePlotlyBaseExt = "PlotlyBase"
 DashBasePlotlyJSExt = "PlotlyJS"
 DashBasePlotsExt = "Plots"
-
-[compat]
-JSON3 = "1"
-Plots = "1"
-julia = "1.6"
-PlotlyBase = "0.8"
-PlotlyJS = "0.18"
-PackageExtensionCompat = "1"
 
 [extras]
 PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
@@ -34,3 +29,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Plots", "PlotlyBase", "PlotlyJS", "PlotlyKaleido"]
+
+[weakdeps]
+PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
+PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/ext/DashBasePlotlyBaseExt.jl
+++ b/ext/DashBasePlotlyBaseExt.jl
@@ -1,8 +1,10 @@
 module DashBasePlotlyBaseExt
 
-import DashBase
-import PlotlyBase
-import PlotlyBase.JSON
+using DashBase
+
+isdefined(Base, :get_extension) ? (using PlotlyBase) : (using ..PlotlyBase)
+
+const JSON = PlotlyBase.JSON
 
 function DashBase.to_dash(p::PlotlyBase.Plot)
     data = JSON.lower(p)

--- a/ext/DashBasePlotlyJSExt.jl
+++ b/ext/DashBasePlotlyJSExt.jl
@@ -1,7 +1,8 @@
 module DashBasePlotlyJSExt
 
-import PlotlyJS
-import DashBase
+using DashBase
+
+isdefined(Base, :get_extension) ? (using PlotlyJS) : (using ..PlotlyJS)
 
 function DashBase.to_dash(p::PlotlyJS.SyncPlot)
     DashBase.to_dash(p.plot)

--- a/ext/DashBasePlotsExt.jl
+++ b/ext/DashBasePlotsExt.jl
@@ -1,8 +1,8 @@
 module DashBasePlotsExt
 
-import Plots
-import DashBase
+using DashBase
 
+isdefined(Base, :get_extension) ? (using Plots) : (using ..Plots)
 
 function DashBase.to_dash(p::Plots.Plot{Plots.PlotlyBackend})
     return if haskey(Base.loaded_modules, Base.PkgId(Base.UUID("a03496cd-edff-5a9b-9e67-9cda94a718b5"), "PlotlyBase")) &&

--- a/src/DashBase.jl
+++ b/src/DashBase.jl
@@ -1,6 +1,5 @@
 module DashBase
 import JSON3
-import PackageExtensionCompat
 include("components.jl")
 include("registry.jl")
 export Component, push_prop!, get_name, get_type, get_namespace,
@@ -9,8 +8,16 @@ get_dash_dependencies, get_dash_renderer_pkg, get_componens_pkgs,
 has_relative_path, has_dev_path, has_external_url, get_type,
 get_external_url, get_dev_path, get_relative_path
 
+@static if !isdefined(Base, :get_extension)
+using Requires
+end
+
 function __init__()
-    PackageExtensionCompat.@require_extensions
+    @static if !isdefined(Base, :get_extension)
+        @require PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5" include("../ext/DashBasePlotlyBaseExt.jl")
+        @require PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a" include("../ext/DashBasePlotlyJSExt.jl")
+        @require Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80" include("../ext/DashBasePlotsExt.jl")
+    end
 end
 
 end # module


### PR DESCRIPTION
using `Requires` dance as suggested by https://pkgdocs.julialang.org/v1.9/creating-packages/#Requires.jl

---

To be merged into https://github.com/plotly/DashBase.jl/pull/9, which has better package extension test than `master`.

